### PR TITLE
fix: new domain requires new baseUrl

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -23,10 +23,10 @@ const config: Config = {
     },
 
     // Set the production url of your site here
-    url: baseDocsUrl,
+    url: 'https://typeorm-pino-logger.js.org',
     // Set the /<baseUrl>/ pathname under which your site is served
     // For GitHub pages deployment, it is often '/<projectName>/'
-    baseUrl: baseDocsPath,
+    baseUrl: '/',
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site configuration to use a custom domain and root path for documentation hosting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->