### PR TITLE
feat: support typeorm 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@ on:
 
 jobs:
   test:
-    name: test (pino ${{ matrix.pino }})
+    name: test (pino ${{ matrix.pino }}, typeorm ${{ matrix.typeorm }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         pino: ["9.7.0", "10.0.0"]
+        typeorm: ["0.3.25", "1.0.0"]
     steps:
       - uses: actions/checkout@v4
 
@@ -22,17 +23,31 @@ jobs:
         with:
           bun-version: latest
 
-      # Install only the deps we need for type-checking/testing, skipping the
-      # frozen lockfile so we can swap pino versions in the matrix. We then
-      # explicitly install both `pino` (consumer) and the project deps without
-      # locking to the committed bun.lock.
-      - name: Install dependencies
+      # Force the matrix peer versions. A plain `bun install <pkg>@<ver> --no-save`
+      # does NOT pin peerDependencies (bun resolves them from the lockfile/range),
+      # so we inject `overrides` and install without the committed lockfile to
+      # guarantee the matrix versions are the ones actually installed.
+      - name: Pin matrix peer versions
         run: |
-          bun install pino@${{ matrix.pino }} typeorm@^0.3.25 --no-save
-          bun install
+          node -e "const fs=require('fs'); const p=require('./package.json'); p.overrides={...(p.overrides||{}), pino:'${{ matrix.pino }}', typeorm:'${{ matrix.typeorm }}'}; fs.writeFileSync('./package.json', JSON.stringify(p,null,4)+'\n')"
+          rm -f bun.lock
 
-      - name: Verify installed pino version
-        run: node -p "require('pino/package.json').version"
+      - name: Install dependencies
+        run: bun install
+
+      - name: Verify installed peer versions
+        run: |
+          PINO=$(node -e "console.log(JSON.parse(require('fs').readFileSync('node_modules/pino/package.json','utf8')).version)")
+          TYPEORM=$(node -e "console.log(JSON.parse(require('fs').readFileSync('node_modules/typeorm/package.json','utf8')).version)")
+          echo "Installed: pino=$PINO typeorm=$TYPEORM"
+          if [ "$PINO" != "${{ matrix.pino }}" ]; then
+            echo "::error::expected pino ${{ matrix.pino }}, got $PINO"
+            exit 1
+          fi
+          if [ "$TYPEORM" != "${{ matrix.typeorm }}" ]; then
+            echo "::error::expected typeorm ${{ matrix.typeorm }}, got $TYPEORM"
+            exit 1
+          fi
 
       - name: Type check
         run: bun run check-types

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     },
     "peerDependencies": {
         "pino": "^9.7.0 || ^10.0.0",
-        "typeorm": "^0.3.25"
+        "typeorm": "^0.3.25 || ^1.0.0"
     },
     "commitlint": {
         "extends": [

--- a/src/TypeOrmPinoLogger.ts
+++ b/src/TypeOrmPinoLogger.ts
@@ -193,8 +193,12 @@ export class TypeOrmPinoLogger implements Logger {
 
         if (queryRunner.connection) {
             const connection = queryRunner.connection;
-            if (connection.name) {
-                context.connectionName = connection.name;
+            // `name` existed on the DataSource/Connection in typeorm 0.3.x but was removed in 1.0.
+            // Read it defensively so this logger compiles against 1.0 while still capturing the
+            // connection name at runtime when used with 0.3.x.
+            const connectionName = (connection as { name?: string }).name;
+            if (connectionName) {
+                context.connectionName = connectionName;
             }
             if (connection.options?.database) {
                 context.database = connection.options.database;

--- a/tests/TypeOrmPinoLogger.test.ts
+++ b/tests/TypeOrmPinoLogger.test.ts
@@ -557,6 +557,33 @@ describe('TypeOrmPinoLogger', () => {
             );
         });
 
+        it('should handle a connection without a name (typeorm 1.0 DataSource)', () => {
+            // typeorm 1.0 removed `name` from DataSource/Connection. The connection still
+            // exposes `options.database`, so the context should omit `connectionName`
+            // without throwing.
+            const mockQueryRunner = {
+                connection: {
+                    options: {
+                        database: 'test_db',
+                    },
+                },
+                isTransactionActive: true,
+            } as unknown as QueryRunner;
+
+            const logger = new TypeOrmPinoLogger(mockLogger, { logQueries: true });
+            logger.logQuery('SELECT * FROM users', undefined, mockQueryRunner);
+
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    queryRunner: {
+                        database: 'test_db',
+                        isTransactionActive: true,
+                    },
+                }),
+                'Executing query'
+            );
+        });
+
         it('should handle undefined queryRunner', () => {
             const logger = new TypeOrmPinoLogger(mockLogger, { logQueries: true });
             logger.logQuery('SELECT * FROM users', undefined, undefined);


### PR DESCRIPTION
## What

Widen the `typeorm` peer range to `^0.3.25 || ^1.0.0` so the logger can be used with typeorm 1.0, while staying compatible with 0.3.x.

## Why

typeorm 1.0 is out, but `typeorm-pino-logger@0.2.0` declares `typeorm: ^0.3.25`, so installing it alongside typeorm 1.0 trips peer-dependency warnings/errors. The logger only implements the stable `Logger` interface, which is unchanged in 1.0, so it works against both majors with one small adjustment.

## The one real code change

typeorm 1.0 removed the `name` property from `DataSource`/`Connection`. `getQueryRunnerContext` read `connection.name`, which no longer type-checks against 1.0. It now reads that field defensively, so the connection name is still captured at runtime on 0.3.x and the code compiles cleanly against both versions:

```ts
const connectionName = (connection as { name?: string }).name;
if (connectionName) {
    context.connectionName = connectionName;
}
```

## Tests

Added a regression case covering a connection that has no `name` but still exposes `options.database` (the typeorm 1.0 shape), asserting the context omits `connectionName` instead of throwing.

## CI

Added a `typeorm` dimension (`0.3.25`, `1.0.0`) to the matrix so the widened range is actually exercised.

While doing this I noticed the existing pino matrix wasn't pinning versions: `bun install pino@<ver> --no-save` doesn't override a peer dependency (bun resolves it from the lockfile/range), so both jobs were running against pino 9.7.0. The matrix now pins each version via `package.json` `overrides` installed without the committed lockfile, and fails the job if the resolved version doesn't match — which fixes the pino axis too.

## Verification

Locally, all four `pino x typeorm` combinations pass `check-types`, `lint`, `test`, and `build`:

| pino | typeorm | result |
|---|---|---|
| 9.7.0 | 0.3.25 | pass |
| 9.7.0 | 1.0.0 | pass |
| 10.0.0 | 0.3.25 | pass |
| 10.0.0 | 1.0.0 | pass |

I intentionally did not bump the package version, since releases here are driven by `release-it` / conventional commits.

---
*Made with AI (model: claude-opus-4.8)*

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for TypeORM 1.0.0 alongside existing 0.3.25 compatibility.

* **Bug Fixes**
  * Improved resilience when TypeORM connection name is unavailable, ensuring consistent logging behavior across versions.

* **Tests**
  * Added test coverage for TypeORM versions without connection name field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->